### PR TITLE
Fix metro configuration for expo-router assets

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,12 +1,9 @@
 const { getDefaultConfig } = require('@expo/metro-config');
-const { resolver: { sourceExts, assetExts } } = getDefaultConfig(__dirname);
 
-module.exports = {
-  transformer: {
-    assetPlugins: ['expo-asset/tools/hashAssetFiles'],
-  },
-  resolver: {
-    sourceExts,
-    assetExts
-  },
-};
+/**
+ * Use Expo's default Metro configuration.
+ * This automatically sets the correct `assetRegistryPath` so images
+ * bundled by packages like `expo-router` resolve properly.
+ */
+module.exports = getDefaultConfig(__dirname);
+


### PR DESCRIPTION
## Summary
- use Expo's default Metro config so assetRegistryPath is included

## Testing
- `npm run lint` *(fails: 4 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68412caf5848832e891588da95c7991d