### PR TITLE
Add Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['expo-router/babel'],
+  };
+};


### PR DESCRIPTION
## Summary
- add `babel.config.js` to include expo router plugin

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416f4ab09c832e8b7e2951bb3cf229