### PR TITLE
Fix business registration fuel icon

### DIFF
--- a/app/auth/business-registration.tsx
+++ b/app/auth/business-registration.tsx
@@ -12,7 +12,7 @@ import {
   Image
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { ArrowLeft, Building, Phone, MapPin, Upload, Store, GasPump, ShoppingBag } from 'lucide-react-native';
+import { ArrowLeft, Building, Phone, MapPin, Upload, Store, Fuel, ShoppingBag } from 'lucide-react-native';
 import { LightTheme } from '@/constants/Colors';
 import AppButton from '@/components/AppButton';
 import { useBusiness } from '@/hooks/useBusiness';
@@ -23,7 +23,7 @@ const BUSINESS_TYPES: { key: BusinessType; label: string; icon: JSX.Element }[] 
   {
     key: 'fuel_station',
     label: 'Fuel Station',
-    icon: <GasPump size={24} color={LightTheme.accent} />
+    icon: <Fuel size={24} color={LightTheme.accent} />
   },
   {
     key: 'retail_shop',


### PR DESCRIPTION
## Summary
- use `Fuel` icon instead of `GasPump`

## Testing
- `npm run lint` *(fails: Cannot resolve react-native-maps, no unused vars warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68419fb9c0fc832ebe1fef0841726dbe