### PR TITLE
Improve missing env var error

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ it so the new variables are loaded.
 
 These environment variables are required when starting the Expo development server or building the app. Variables prefixed with `EXPO_PUBLIC_` are automatically exposed to the client by Expo.
 
+If you see an error like `Missing Supabase environment variables`, double-check that the `.env` file exists, contains your Supabase credentials and that you've restarted the development server.
+
 3. Start the development server:
 
 ```bash

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -3,10 +3,13 @@ import { Database } from '@/types/supabase';
 import 'react-native-url-polyfill/auto';
 
 // Initialize the Supabase client
-const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!;
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
+  console.error(
+    'Supabase credentials are missing. Copy `.env.example` to `.env`, add your credentials and restart the development server.'
+  );
   throw new Error('Missing Supabase environment variables');
 }
 


### PR DESCRIPTION
## Summary
- clarify setup instructions for Supabase env vars
- print helpful message when Supabase env vars are missing

## Testing
- `npm run lint` *(fails: `lint` is not an expo command)*

------
https://chatgpt.com/codex/tasks/task_e_687f7caed840832ea1e8cbce9f007188