### PR TITLE
Enable OpenStreetMap on mobile

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -14,6 +14,7 @@ interface MapComponentProps {
 }
 
 const WebMapComponent = React.lazy(() => import('./WebMapComponent'));
+import MobileMapComponent from './MobileMapComponent';
 
 export default function MapComponent(props: MapComponentProps) {
   if (Platform.OS === 'web') {
@@ -29,11 +30,7 @@ export default function MapComponent(props: MapComponentProps) {
     );
   }
 
-  return (
-    <View style={styles.container}>
-      <Text>Map is only available on web platform</Text>
-    </View>
-  );
+  return <MobileMapComponent {...props} />;
 }
 
 const styles = StyleSheet.create({

--- a/components/MobileMapComponent.tsx
+++ b/components/MobileMapComponent.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef } from 'react';
+import { StyleSheet, Dimensions, View, Text } from 'react-native';
+import MapView, { Marker, UrlTile, Circle, Callout, PROVIDER_DEFAULT } from 'react-native-maps';
+import { Report } from '@/types';
+import { Colors } from '@/constants/Colors';
+import ReportMarker from './ReportMarker';
+
+interface MapComponentProps {
+  center: [number, number];
+  zoom: number;
+  reports: Report[];
+  selectedReport: Report | null;
+  onMarkerClick: (report: Report) => void;
+  onScroll?: (event: any) => void;
+  filteredCategories?: string[];
+}
+
+const zoomToDelta = (zoom: number) => {
+  const { width, height } = Dimensions.get('window');
+  const latDelta = Math.exp(Math.log(360) - zoom * Math.LN2);
+  const lngDelta = latDelta * (width / height);
+  return { latitudeDelta: latDelta, longitudeDelta: lngDelta };
+};
+
+export default function MobileMapComponent({
+  center,
+  zoom,
+  reports,
+  selectedReport,
+  onMarkerClick,
+  onScroll,
+  filteredCategories = [],
+}: MapComponentProps) {
+  const mapRef = useRef<MapView | null>(null);
+  const region = {
+    latitude: center[0],
+    longitude: center[1],
+    ...zoomToDelta(zoom),
+  };
+
+  useEffect(() => {
+    if (mapRef.current) {
+      mapRef.current.animateToRegion(region, 200);
+    }
+  }, [region]);
+
+  const visibleReports =
+    filteredCategories.length > 0
+      ? reports.filter(r => filteredCategories.includes(r.category))
+      : reports;
+
+  return (
+    <MapView
+      ref={mapRef}
+      style={styles.map}
+      provider={PROVIDER_DEFAULT}
+      onScroll={onScroll}
+      initialRegion={region}
+    >
+      <UrlTile
+        urlTemplate="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        maximumZ={19}
+      />
+      <Circle
+        center={{ latitude: center[0], longitude: center[1] }}
+        radius={500}
+        strokeColor={Colors.accent}
+        fillColor="rgba(63,81,181,0.05)"
+      />
+      <Marker
+        coordinate={{ latitude: center[0], longitude: center[1] }}
+        tracksViewChanges={false}
+      >
+        <Callout>
+          <CalloutView />
+        </Callout>
+      </Marker>
+      {visibleReports.map(report => (
+        <ReportMarker
+          key={report.id}
+          report={report}
+          onPress={onMarkerClick}
+          selected={selectedReport?.id === report.id}
+        />
+      ))}
+    </MapView>
+  );
+}
+
+function CalloutView() {
+  return (
+    <View style={{ padding: 4 }}>
+      <Text style={{ fontSize: 12, fontWeight: 'bold' }}>Your Location</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  map: {
+    flex: 1,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-leaflet": "^4.2.1",
         "react-native": "^0.79.3",
         "react-native-gesture-handler": "~2.24.0",
+        "react-native-maps": "^1.5.0",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.3.0",
         "react-native-screens": "~4.10.0",
@@ -3680,7 +3681,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
@@ -8292,6 +8292,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.24.10",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.24.10.tgz",
+      "integrity": "sha512-Gbx1K1+urx1cBT7tew2Xi4pd/hpKdzCZTg2ayeLj9e86Yt/sc8olEHaDOTg2klNuu9uf3qDXc98aml1mYbzy9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-leaflet": "^4.2.1",
     "react-native": "^0.79.3",
     "react-native-gesture-handler": "~2.24.0",
+    "react-native-maps": "^1.5.0",
     "react-native-reanimated": "~3.17.4",
     "react-native-safe-area-context": "5.3.0",
     "react-native-screens": "~4.10.0",


### PR DESCRIPTION
## Summary
- add `react-native-maps` to dependencies
- implement `MobileMapComponent` using `react-native-maps`
- update `MapComponent` to render mobile or web maps appropriately

## Testing
- `npm run lint` *(fails: shows lint errors but runs)*

------
https://chatgpt.com/codex/tasks/task_e_687f84714678832e84a9ac7f86109122