### PR TITLE
Fix web bundling by lazy loading mobile map component

### DIFF
--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -14,7 +14,6 @@ interface MapComponentProps {
 }
 
 const WebMapComponent = React.lazy(() => import('./WebMapComponent'));
-import MobileMapComponent from './MobileMapComponent';
 
 export default function MapComponent(props: MapComponentProps) {
   if (Platform.OS === 'web') {
@@ -30,6 +29,7 @@ export default function MapComponent(props: MapComponentProps) {
     );
   }
 
+  const MobileMapComponent = require('./MobileMapComponent').default;
   return <MobileMapComponent {...props} />;
 }
 


### PR DESCRIPTION
## Summary
- avoid importing react-native-maps when bundling for web by requiring the mobile map component at runtime

## Testing
- `npm run lint` *(fails: 5 errors, 29 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687f880c7868832ea44a2fe511d0664f