### PR TITLE
Disable new architecture

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",
     "userInterfaceStyle": "automatic",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "ios": {
       "supportsTablet": true
     },


### PR DESCRIPTION
## Summary
- disable React Native new architecture in `app.json` because `react-native-maps` isn't compatible

## Testing
- `npm run lint` *(fails: No ESLint config found / 5 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880a1a1d3a4832e8c72eb873533637c