### PR TITLE
Fix alert icon reference

### DIFF
--- a/components/CategoryIconToolbar.tsx
+++ b/components/CategoryIconToolbar.tsx
@@ -76,7 +76,7 @@ const CATEGORY_CONFIG = [
   },
   {
     key: 'safety' as ReportCategory,
-    icon: TriangleAlert,
+    icon: AlertTriangle,
     color: '#E53935',
     label: 'Safety'
   }


### PR DESCRIPTION
## Summary
- use the `AlertTriangle` icon in `CategoryIconToolbar`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6881eef8430c832ea3cc786b44ad54d6