### PR TITLE
Fix duplicate detail balloon

### DIFF
--- a/components/AnimatedReportPin.tsx
+++ b/components/AnimatedReportPin.tsx
@@ -17,7 +17,6 @@ interface AnimatedReportPinProps {
   report: Report;
   isSelected?: boolean;
   isHighlighted?: boolean;
-  onPress?: () => void;
 }
 
 const CATEGORY_CONFIG = {
@@ -63,11 +62,10 @@ const CATEGORY_CONFIG = {
   }
 };
 
-export default function AnimatedReportPin({ 
-  report, 
-  isSelected = false, 
+export default function AnimatedReportPin({
+  report,
+  isSelected = false,
   isHighlighted = false,
-  onPress 
 }: AnimatedReportPinProps) {
   const config = CATEGORY_CONFIG[report.category];
   const IconComponent = config.icon;

--- a/components/ReportMarker.tsx
+++ b/components/ReportMarker.tsx
@@ -23,15 +23,13 @@ export default function ReportMarker({
         latitude: report.location.latitude,
         longitude: report.location.longitude,
       }}
-      onPress={() => onPress(report)}
       tracksViewChanges={false}
     >
       <TouchableOpacity onPress={() => onPress(report)} activeOpacity={0.8}>
-        <AnimatedReportPin 
-          report={report} 
+        <AnimatedReportPin
+          report={report}
           isSelected={selected}
           isHighlighted={highlighted}
-          onPress={() => onPress(report)}
         />
       </TouchableOpacity>
     </Marker>


### PR DESCRIPTION
## Summary
- avoid triggering map marker press multiple times
- remove unused pin press prop

## Testing
- `npm run lint` *(fails: Unable to fetch compatibility data from React Native Directory)*

------
https://chatgpt.com/codex/tasks/task_e_6881f6aadbfc832ea66aa72bed805ae8