### PR TITLE
Add Expo lint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ npm run dev
 ```
 
 If the environment variables are missing, the app will throw an error during startup.
+
+## Linting
+
+This project uses Expo's built-in linter. To run the lint checks locally first install the dependencies and then run the `lint` script:
+
+```bash
+npm install
+npm run lint
+```
+
+The script uses `npx expo` so you do not need to install the Expo CLI globally.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
-    "lint": "expo lint"
+    "lint": "npx expo lint"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -51,6 +51,8 @@
     "@babel/core": "^7.25.2",
     "@types/leaflet": "^1.9.8",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "eslint": "^9.0.0",
+    "eslint-config-expo": "~9.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- use `npx expo` in the lint script
- document how to run the linter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880bb022620832eba34a22f9ee8f220