### PR TITLE
Add map pin detail balloons

### DIFF
--- a/components/ReportMarker.tsx
+++ b/components/ReportMarker.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { StyleSheet, View, TouchableOpacity } from 'react-native';
-import { Marker } from 'react-native-maps';
+import { StyleSheet, View, Text } from 'react-native';
+import { Marker, Callout } from 'react-native-maps';
 import { Report, ReportCategory } from '@/types';
 import AnimatedReportPin from './AnimatedReportPin';
 
@@ -11,11 +11,11 @@ interface ReportMarkerProps {
   highlighted?: boolean;
 }
 
-export default function ReportMarker({ 
-  report, 
-  onPress, 
-  selected = false, 
-  highlighted = false 
+export default function ReportMarker({
+  report,
+  onPress,
+  selected = false,
+  highlighted = false
 }: ReportMarkerProps) {
   return (
     <Marker
@@ -24,16 +24,38 @@ export default function ReportMarker({
         longitude: report.location.longitude,
       }}
       tracksViewChanges={false}
+      onPress={() => onPress(report)}
     >
-      <TouchableOpacity onPress={() => onPress(report)} activeOpacity={0.8}>
-        <AnimatedReportPin
-          report={report}
-          isSelected={selected}
-          isHighlighted={highlighted}
-        />
-      </TouchableOpacity>
+      <AnimatedReportPin
+        report={report}
+        isSelected={selected}
+        isHighlighted={highlighted}
+      />
+      <Callout tooltip>
+        <View style={styles.calloutContainer}>
+          <Text style={styles.calloutTitle}>{report.title}</Text>
+          {report.description ? (
+            <Text style={styles.calloutSubtitle} numberOfLines={2}>
+              {report.description}
+            </Text>
+          ) : null}
+        </View>
+      </Callout>
     </Marker>
   );
 }
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  calloutContainer: {
+    padding: 8,
+    maxWidth: 200,
+  },
+  calloutTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 2,
+  },
+  calloutSubtitle: {
+    fontSize: 12,
+  },
+});

--- a/components/WebMapComponentClient.tsx
+++ b/components/WebMapComponentClient.tsx
@@ -453,6 +453,14 @@ export default function WebMapComponentClient({
                 click: () => onMarkerClick(report)
               }}
             >
+              <Popup>
+                <div style={{ maxWidth: '200px' }}>
+                  <strong>{report.title}</strong>
+                  {report.description && (
+                    <p style={{ margin: '4px 0' }}>{report.description}</p>
+                  )}
+                </div>
+              </Popup>
             </Marker>
           );
         })}


### PR DESCRIPTION
## Summary
- display callouts for incident pins on mobile map
- show popup with basic info for web map markers

## Testing
- `npm run lint` *(fails: 6 errors, 45 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6881f8f633a0832ea51cc4b6c042c326