### PR TITLE
Enable incident details preview on map hover

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -76,6 +76,14 @@ export default function MapScreen() {
     trackInteraction(); // Reset idle timer on interaction
   };
 
+  const handleMarkerHover = (report: Report) => {
+    setSelectedReport(report);
+  };
+
+  const handleMarkerHoverOut = () => {
+    setSelectedReport(null);
+  };
+
   const handleClosePreview = () => {
     setSelectedReport(null);
     trackInteraction();
@@ -178,6 +186,8 @@ export default function MapScreen() {
         reports={filteredReports}
         selectedReport={selectedReport}
         onMarkerClick={handleMarkerClick}
+        onMarkerHover={handleMarkerHover}
+        onMarkerHoverOut={handleMarkerHoverOut}
         highlightedReports={highlightedReports}
         onScroll={Animated.event(
           [{ nativeEvent: { contentOffset: { y: headerAnimation } } }],

--- a/components/MapComponent.tsx
+++ b/components/MapComponent.tsx
@@ -11,6 +11,8 @@ interface MapComponentProps {
   highlightedReports?: Report[];
   filteredCategories?: ReportCategory[];
   onMarkerClick: (report: Report) => void;
+  onMarkerHover?: (report: Report) => void;
+  onMarkerHoverOut?: () => void;
   onScroll?: (event: any) => void;
 }
 

--- a/components/MobileMapComponent.tsx
+++ b/components/MobileMapComponent.tsx
@@ -13,6 +13,8 @@ interface MapComponentProps {
   highlightedReports?: Report[];
   filteredCategories?: ReportCategory[];
   onMarkerClick: (report: Report) => void;
+  onMarkerHover?: (report: Report) => void;
+  onMarkerHoverOut?: () => void;
   onScroll?: (event: any) => void;
 }
 
@@ -31,6 +33,8 @@ export default function MobileMapComponent({
   highlightedReports = [],
   filteredCategories,
   onMarkerClick,
+  onMarkerHover,
+  onMarkerHoverOut,
   onScroll,
 }: MapComponentProps) {
   const mapRef = useRef<MapView | null>(null);

--- a/components/WebMapComponent.tsx
+++ b/components/WebMapComponent.tsx
@@ -10,6 +10,8 @@ interface MapComponentProps {
   reports: Report[];
   selectedReport: Report | null;
   onMarkerClick: (report: Report) => void;
+  onMarkerHover?: (report: Report) => void;
+  onMarkerHoverOut?: () => void;
   onScroll?: (event: any) => void;
 }
 

--- a/components/WebMapComponentClient.tsx
+++ b/components/WebMapComponentClient.tsx
@@ -14,6 +14,8 @@ interface MapComponentProps {
   highlightedReports?: Report[];
   filteredCategories?: ReportCategory[];
   onMarkerClick: (report: Report) => void;
+  onMarkerHover?: (report: Report) => void;
+  onMarkerHoverOut?: () => void;
   onScroll?: (event: any) => void;
 }
 
@@ -35,6 +37,8 @@ export default function WebMapComponentClient({
   selectedReport,
   highlightedReports = [],
   onMarkerClick,
+  onMarkerHover,
+  onMarkerHoverOut,
   onScroll,
   filteredCategories = []
 }: MapComponentProps) {
@@ -471,10 +475,12 @@ export default function WebMapComponentClient({
                 mouseover: (e) => {
                   const marker = e.target;
                   marker.openPopup();
+                  onMarkerHover?.(report);
                 },
                 mouseout: (e) => {
                   const marker = e.target;
                   marker.closePopup();
+                  onMarkerHoverOut?.();
                 }
               }}
             >


### PR DESCRIPTION
## Summary
- add optional `onMarkerHover` and `onMarkerHoverOut` callbacks to `MapComponent`
- show incident preview when hovering markers on the web map
- forward hover callbacks from screen to map

## Testing
- `npm run lint` *(fails: expo not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881fe8b18bc832eab4dd18c457fb1f6